### PR TITLE
Adds fix for incorrect height of body

### DIFF
--- a/nerdlets/root/analyzer.js
+++ b/nerdlets/root/analyzer.js
@@ -103,12 +103,12 @@ export default class Analyzer extends React.Component {
     const Header = dataType == 'metric' ? MetricsHeader : EventsHeader
 
     return <>
-      <Header {...this.props} {...this.state} 
-        setAttribute={this._setAttribute} 
-        setFunction={this._setFunction} 
-        setEventType={this._setEventType} />      
+      <Header {...this.props} {...this.state}
+        setAttribute={this._setAttribute}
+        setFunction={this._setFunction}
+        setEventType={this._setEventType} />
       <Filters {...this.props} {...this.state} removeFilter={this._removeFilter} />
-      <Grid className="primary-body-stack-item-grid">
+      <Grid className={`primary-body-stack-item-grid ${Object.keys(this.state.filters).length > 0 ? 'has-filters' : ''}`}>
         <GridItem columnSpan={3} collapseGapAfter className="col-1">
           <DimensionPicker {...this.props} {...this.state} setDimension={this._setDimension} />
         </GridItem>

--- a/nerdlets/root/styles.scss
+++ b/nerdlets/root/styles.scss
@@ -270,8 +270,12 @@
 .primary-body-stack-item-grid {
   height: 100%;
   grid-template-rows: 100%;
-  height: calc(100% - 106px);
+  height: calc(100% - 60px);
   border-top: 1px solid #E7E7E7;
+
+  &.has-filters {
+    height: calc(100% - 100px);
+  }
 }
 
 .col-1-tabs-container {


### PR DESCRIPTION
Noticed an styling issue with the height of the body (`primary-body-stack-item-grid`). It was changing based on whether or not there were any active filters. So I added a class to that element based on whether or not there are any active filters. This solves the problem wonderfully.