### PR TITLE
Handle old and new NerdGraph NRQL uniques reponse structure

### DIFF
--- a/nerdlets/root/metrics/metric-picker.js
+++ b/nerdlets/root/metrics/metric-picker.js
@@ -41,10 +41,10 @@ export default class MetricPicker extends React.Component {
   async loadMetricNames() {
     const { account, setAttribute, setEventType } = this.props
 
-    const nrql = `SELECT uniques(metricName) FROM Metric`
+    const nrql = `SELECT uniques(metricName) as member FROM Metric`
     const results = await nrdbQuery(account.id, nrql)
 
-    const metricNames = results.map(r => r.member).sort()
+    const metricNames = results.map(r => r.member).flat().sort()
     this.setState({ metricNames })
 
     if (metricNames.length > 0) {


### PR DESCRIPTION
This PR adapts to an upcoming change in the response structure for `uniques` results fetched via NerdGraph.

tldr; The items will be returned under a single attribute as a list instead of a list of individual items.

This code adapts to handle both cases by aliasing the attribute such that the new list comes back under the same key as an individual item used to, and simply flattens the resulting list.

sidekick/ @tangollama - ping me if you have questions