### PR TITLE
fix: account picker styles

### DIFF
--- a/nerdlets/root/styles.scss
+++ b/nerdlets/root/styles.scss
@@ -371,9 +371,8 @@
   padding: 8px 0 8px;
 }
 
-.accountPicker [class*=wnd-Dropdown-trigger] {
-  position: relative;
-  right: 9px;
+.accountPicker {
+  margin-right: 16px;
 }
 
 [class*=TableHeaderCell-title] {


### PR DESCRIPTION
The account picker styles we're funky. This PR fixes them:
<img width="610" alt="Captura de Pantalla 2020-03-26 a la(s) 9 13 21 a  m" src="https://user-images.githubusercontent.com/812989/77650570-12134980-6f42-11ea-8169-72a1b72cb533.png">

---
Closes newrelic#27