### PR TITLE
fix: z-index of function dropdown popover

### DIFF
--- a/nerdlets/root/styles.scss
+++ b/nerdlets/root/styles.scss
@@ -379,3 +379,7 @@
 [class*=TableHeaderCell-title] {
   border-bottom: none;
 }
+
+.react-select__menu {
+  z-index: 100;
+}


### PR DESCRIPTION
The popover from the "function" dropdown would under the legend of a pie chart. This PR fixes that behavior:
<img width="923" alt="Captura de Pantalla 2020-03-26 a la(s) 9 27 32 a  m" src="https://user-images.githubusercontent.com/812989/77652049-0a54a480-6f44-11ea-963e-dc45617f9ffb.png">


---
Closes newrelic#28