### PR TITLE
attributes like "average-join.time" must be quoted

### DIFF
--- a/nerdlets/lib/quote.js
+++ b/nerdlets/lib/quote.js
@@ -15,6 +15,7 @@ const KEYWORDS = {
   by: true,
   nocache: true,
   join: true,
+  events: true,
   end: true
 };
 
@@ -30,7 +31,7 @@ export default function quote(s) {
   if (KEYWORDS[s.toLowerCase()]) {
     doQuote = true;
   }
-  s.split(/[\.-]/).forEach(term => {
+  s.split(/[\.-_]/).forEach(term => {
     term = term.toLowerCase();
     if (KEYWORDS[term]) {
       doQuote = true;

--- a/nerdlets/lib/quote.js
+++ b/nerdlets/lib/quote.js
@@ -14,20 +14,32 @@ const KEYWORDS = {
   order: true,
   by: true,
   nocache: true,
+  join: true,
   end: true
 };
 
 export default function quote(s) {
+  let doQuote = false
   if (!s) return '';
 
   /* eslint-disable no-useless-escape */
   if (s.match(/[\s:-@#\!\\\/]/)) {
-    return `\`${s}\``;
+    doQuote = true
   }
   /* eslint-enable */
 
   if (KEYWORDS[s.toLowerCase()]) {
-    return `\`${s}\``;
+    doQuote = true
   }
-  return s;
+  s.split(/[\.-]/).forEach(term => {
+    term = term.toLowerCase()
+    if (KEYWORDS[term]) {
+      doQuote = true
+    }
+  })
+
+  if(doQuote) 
+    return `\`${s}\`` 
+  else 
+   return s;
 }

--- a/nerdlets/lib/quote.js
+++ b/nerdlets/lib/quote.js
@@ -19,27 +19,25 @@ const KEYWORDS = {
 };
 
 export default function quote(s) {
-  let doQuote = false
+  let doQuote = false;
   if (!s) return '';
 
   /* eslint-disable no-useless-escape */
   if (s.match(/[\s:-@#\!\\\/]/)) {
-    doQuote = true
+    doQuote = true;
   }
-  /* eslint-enable */
 
   if (KEYWORDS[s.toLowerCase()]) {
-    doQuote = true
+    doQuote = true;
   }
   s.split(/[\.-]/).forEach(term => {
-    term = term.toLowerCase()
+    term = term.toLowerCase();
     if (KEYWORDS[term]) {
-      doQuote = true
+      doQuote = true;
     }
-  })
+  });
+  /* eslint-enable */
 
-  if(doQuote) 
-    return `\`${s}\`` 
-  else 
-   return s;
+  if (doQuote) return `\`${s}\``;
+  else return s;
 }


### PR DESCRIPTION
`quote()` must also explicitly quote a string that has a keyword inside it, separated by dots or dashes. For example, if this attribute name isn't quoted, the NRQL query will fail because it has "join" inside a dot or dash separated segment: `consumer-coordinator-metrics.join-time-avg`